### PR TITLE
fix naturality law for Traversable

### DIFF
--- a/src/Course/Traversable.hs
+++ b/src/Course/Traversable.hs
@@ -13,7 +13,7 @@ import Course.List
 -- laws are not checked by the compiler. These laws are given as:
 --
 -- * The law of naturality
---   `∀f g. f . traverse ≅ traverse (f . g)`
+--   `∀f g. f . traverse g ≅ traverse (f . g)`
 --
 -- * The law of identity
 --   `∀x. traverse Id x ≅ Id x`


### PR DESCRIPTION
typo