### PR TITLE
Added missing ">>>" in front of doctest expression for mapParser

### DIFF
--- a/src/Course/Parser.hs
+++ b/src/Course/Parser.hs
@@ -108,7 +108,7 @@ character =
 -- >>> parse (mapParser succ character) "amz"
 -- Result >mz< 'b'
 --
--- parse (mapParser (+10) (valueParser 7)) ""
+-- >>> parse (mapParser (+10) (valueParser 7)) ""
 -- Result >< 17
 mapParser ::
   (a -> b)


### PR DESCRIPTION
One of the tests in `Parser.hs` wasn't running because it was missing the `>>>` bit at the start.