### PR TITLE
Use -ferror-spans

### DIFF
--- a/course.cabal
+++ b/course.cabal
@@ -44,6 +44,7 @@ library
                       -fno-warn-unused-do-bind
                       -fno-warn-unused-imports
                       -fno-warn-type-defaults
+                      -ferror-spans
 
   default-extensions: NoImplicitPrelude
                       ScopedTypeVariables


### PR DESCRIPTION
This helps Leksah underline the correct span and highlight the right error when the span is selected in the editor.