### PR TITLE
Run doctests in preferred order.

### DIFF
--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,23 +1,29 @@
 module Main where
 
-import Build_doctests (deps)
 import Control.Applicative
+import Prelude
+import Build_doctests (deps)
 import Control.Monad
 import Data.List
+import Data.Monoid
 import System.Directory
 import System.FilePath
+import System.IO
 import Test.DocTest
 
 main ::
   IO ()
 main =
-  getSources >>= \sources -> doctest $
-      "-isrc"
-    : "-idist/build/autogen"
-    : "-optP-include"
-    : "-optPdist/build/autogen/cabal_macros.h"
-    : "-hide-all-packages"
-    : map ("-package="++) deps ++ sources
+  getSources >>= \sources ->
+    forM_ (preferredOrderFirst sources) $ \source -> do
+      hPutStrLn stderr $ "Testing " <> source
+      doctest $
+          "-isrc"
+        : "-idist/build/autogen"
+        : "-optP-include"
+        : "-optPdist/build/autogen/cabal_macros.h"
+        : "-hide-all-packages"
+        : map ("-package="++) deps ++ [source]
 
 sourceDirectories ::
   [FilePath]
@@ -25,6 +31,39 @@ sourceDirectories =
   [
     "src"
   ]
+
+preferredOrderFirst :: [FilePath] -> [FilePath]
+preferredOrderFirst sources =
+     filter (`elem`    sources       ) preferredOrder
+  <> filter (`notElem` preferredOrder) sources
+
+-- If you find the tests are running slowly.
+-- Comment out the Modules you have completed
+-- in the list below.
+preferredOrder :: [String]
+preferredOrder = map (\f -> "src/Course" </> f <.> "hs") [
+      "List"
+    , "Functor"
+    , "Apply"
+    , "Applicative"
+    , "Bind"
+    , "Monad"
+    , "FileIO"
+    , "State"
+    , "StateT"
+    , "Extend"
+    , "Comonad"
+    , "Compose"
+    , "Traversable"
+    , "ListZipper"
+    , "Parser"
+    , "MoreParser"
+    , "JsonParser"
+    , "Interactive"
+    , "Anagrams"
+    , "FastAnagrams"
+    , "Cheque"
+    ]
 
 isSourceFile ::
   FilePath


### PR DESCRIPTION
It stops after the first module with failures in it.  Not sure if this
is a bug or a feature.  Keeps the failure list short, but may be
anoying to people who want to skip ahead.