### PR TITLE
function monad

### DIFF
--- a/src/Course/Apply.hs
+++ b/src/Course/Apply.hs
@@ -68,7 +68,7 @@ instance Apply Optional where
   (<*>) =
     error "todo: Course.Apply (<*>)#instance Optional"
 
--- | Implement @Apply@ instance for reader.
+-- | Implement @Apply@ instance for the function monad.
 --
 -- >>> ((+) <*> (+10)) 3
 -- 16

--- a/src/Course/Bind.hs
+++ b/src/Course/Bind.hs
@@ -109,7 +109,7 @@ instance Bind Optional where
   (=<<) =
     error "todo: Course.Bind (=<<)#instance Optional"
 
--- | Binds a function on the reader ((->) t).
+-- | Binds a function on the function monad ((->) t).
 --
 -- >>> ((*) =<< (+10)) 7
 -- 119

--- a/src/Course/Functor.hs
+++ b/src/Course/Functor.hs
@@ -74,7 +74,7 @@ instance Functor Optional where
   (<$>) =
     error "todo: Course.Functor (<$>)#instance Optional"
 
--- | Maps a function on the reader ((->) t) functor.
+-- | Maps a function on the function ((->) t) monad.
 --
 -- >>> ((+1) <$> (*2)) 8
 -- 17


### PR DESCRIPTION
I'm new-ish to Haskell, but I'm wondering if the references to 'reader'
should be changed to the 'function monad'? I was trying to understand
((->) t) by searching on 'reader', and got results like
https://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Reader.html.
However, searching on 'function monad' gave me these pages, which seem
more relevant: http://www.mjoldfield.com/atelier/2014/07/monads-fn.html
and http://stackoverflow.com/questions/14430397/about-the-function-monad