### PR TITLE
State.hs :: revert back previous change

### DIFF
--- a/src/Course/State.hs
+++ b/src/Course/State.hs
@@ -133,7 +133,7 @@ put =
 -- >>> let p x = (\s -> (const $ pure (x == 'c')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 0
 -- (Full 'c',3)
 --
--- >>> let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 8
+-- >>> let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 0
 -- (Empty,8)
 findM ::
   Monad f =>


### PR DESCRIPTION
The original was indeed correct. 
This is for reverting back the change.
My apologies.