### PR TITLE
State:findM fix error in test

### DIFF
--- a/src/Course/State.hs
+++ b/src/Course/State.hs
@@ -129,7 +129,7 @@ put =
 -- (Full 'c',3)
 --
 -- >>> let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 8
--- (Empty,8)
+-- (Empty,16)
 findM ::
   Monad f =>
   (a -> f Bool)


### PR DESCRIPTION
let p x = (\s -> (const $ pure (x == 'i')) =<< put (1+s)) =<< get in runState (findM p $ listh ['a'..'h']) 8

The test is starting with state 8 so after iterating over a-h it will
have value of 16 instead of the expected 8