### PR TITLE
Bind apply readme patch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,9 +182,7 @@ step is to complete the exercises in `Course.List`.
 After this, the following progression of modules is recommended:
 
 * `Course.Functor`
-* `Course.Apply`
 * `Course.Applicative`
-* `Course.Bind`
 * `Course.Monad` (please see [this issue](https://github.com/NICTA/course/issues/118))
 * `Course.FileIO`
 * `Course.State`

--- a/src/Course/MonadTutorial.hs
+++ b/src/Course/MonadTutorial.hs
@@ -24,11 +24,7 @@ and burn result.
 
 Please complete the following exercises before proceeding:
 * Course/Functor
-* Course/Apply
 * Course/Applicative
-
-Optionally, for even more rigorous preparation, also complete the Course/Bind
-exercises.
 --------------------------------------------------------------------------------
 
 In this source file, you will find a recurring pattern:

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -44,9 +44,7 @@ preferredOrder :: [String]
 preferredOrder = map (\f -> "src/Course" </> f <.> "hs") [
       "List"
     , "Functor"
-    , "Apply"
     , "Applicative"
-    , "Bind"
     , "Monad"
     , "FileIO"
     , "State"


### PR DESCRIPTION
Update the suggested progression in the README and the comments in Monad.Tutorial to avoid confusion with the removal of Apply/Bind. Also removes the modules from the preferred order in doctests.hs