### PR TITLE
Fix Extend associativity law definition

### DIFF
--- a/src/Course/Extend.hs
+++ b/src/Course/Extend.hs
@@ -14,7 +14,7 @@ import Course.Functor
 -- is not checked by the compiler. This law is given as:
 --
 -- * The law of associativity
---   `∀f g x. (f <<=) . (g <<=) ≅ (f . (g <<=) <<=)
+--   `∀f g. (f <<=) . (g <<=) ≅ (f . (g <<=) <<=)
 class Functor f => Extend f where
   -- Pronounced, extend.
   (<<=) ::

--- a/src/Course/Extend.hs
+++ b/src/Course/Extend.hs
@@ -14,7 +14,7 @@ import Course.Functor
 -- is not checked by the compiler. This law is given as:
 --
 -- * The law of associativity
---   `∀f g x. (f <<=) . (g <<=) ≅ (<<=) (f . (g <<=) <<=)
+--   `∀f g x. (f <<=) . (g <<=) ≅ (f . (g <<=) <<=)
 class Functor f => Extend f where
   -- Pronounced, extend.
   (<<=) ::


### PR DESCRIPTION
```haskell
-- | All instances of the `Extend` type-class must satisfy one law. This law
-- is not checked by the compiler. This law is given as:
--
-- * The law of associativity
--   `∀f g x. (f <<=) . (g <<=) ≅ (<<=) (f . (g <<=) <<=)
class Functor f => Extend f where
  -- Pronounced, extend.
  (<<=) ::
    (f a -> b)
    -> f a
    -> f b
```

I tried working out the types:

```haskell
f :: f b -> c
(f <<=) :: f b -> f c
g :: f a -> b
(g <<=) :: f a -> f b
(f <<=) . (g <<=) :: f a -> f c

(f . (g <<=)) :: f a -> c
(f . (g <<=) <<=) :: f a -> f c -- good here
(<<=) (f . (g <<=) <<=) :: f a -> f (f c) -- we've gone too far
```

I'm thinking the leading `(<<=)` on the right hand side of the law is erroneous. Is that right?